### PR TITLE
Using exact version of ng-grid in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,6 +12,6 @@
         "angular-touch": "~1.3.0"
     },
     "devDependencies": {
-        "ng-grid": "~2.0.12"
+        "ng-grid": "=2.0.12"
     }
 }


### PR DESCRIPTION
The newer versions of ng-grid need modification in the index.html, that makes difficulties for beginers.
